### PR TITLE
feat: added deal statistics (sum, count, sizes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,53 @@ Rest API for Delta Global Metrics
 make dmr
 ```
 
+## Global Stats available
+- total deals attempted
+- total e2e deals attempted
+- total import deals attempted
+- total deals succeeded
+- total e2e deals succeeded
+- total import deals succeeded
+- total deals failed
+- total e2e deals failed
+- total import deals failed
+- total deals active
+- total e2e deals active
+- total import deals active
+- total number of sps
+- total number of delta nodes
+
+## Storage stats available
+- total storage consumed by deals attempted
+- total storage consumed by e2e deals attempted
+- total storage consumed by import deals attempted
+- total storage consumed by deals succeeded
+- total storage consumed by e2e deals succeeded
+- total storage consumed by import deals succeeded
+- total storage consumed by deals failed
+- total storage consumed by e2e deals failed
+- total storage consumed by import deals failed
+- total storage consumed by deals active
+- total storage consumed by e2e deals active
+- total storage consumed by import deals active
+- total storage consumed by all deals
+- total storage consumed by all e2e deals
+
+## SP
+- list of SP
+- list of SP location
+- list of SP deals attempted
+- list of SP deals succeeded
+- list of SP deals failed
+- list of SP deals active
+- list of SP deals attempted by e2e
+- list of SP deals succeeded by e2e
+- list of SP deals failed by e2e
+- list of SP deals active by e2e
+- list of SP deals attempted by import
+- list of SP deals succeeded by import
+- list of SP deals failed by import
+
+
 # Author
 Protocol Labs Outercore Engineering.

--- a/dao/dao_base.go
+++ b/dao/dao_base.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/eko/gocache/store/bigcache/v4"
 	"github.com/jinzhu/gorm"
+	explru "github.com/paskal/golang-lru/simplelru"
 	"reflect"
 )
 
@@ -55,7 +55,7 @@ var (
 	// DB reference to database
 	DB *gorm.DB
 
-	Cacher bigcache.BigcacheStore
+	Cacher *explru.ExpirableLRU
 
 	// AppBuildInfo reference to build info
 	AppBuildInfo *BuildInfo

--- a/dao/dao_base.go
+++ b/dao/dao_base.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-
+	"github.com/eko/gocache/store/bigcache/v4"
 	"github.com/jinzhu/gorm"
+	"reflect"
 )
 
 // BuildInfo is used to define the application build info, and inject values into via the build process.
@@ -54,6 +54,8 @@ var (
 
 	// DB reference to database
 	DB *gorm.DB
+
+	Cacher bigcache.BigcacheStore
 
 	// AppBuildInfo reference to build info
 	AppBuildInfo *BuildInfo

--- a/dao/statistics.go
+++ b/dao/statistics.go
@@ -1,27 +1,85 @@
 package dao
 
+import (
+	"fmt"
+	"github.com/application-research/delta-metrics-rest/model"
+)
+
 // function to get all totals info
 func GetOpenTotalInfoStats() (interface{}, error) {
 
 	var totalContentConsumed int64
-	DB.Raw("select count(*) from content_logs").Count(&totalContentConsumed)
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//         SELECT COUNT(*) as cnt
+	//         FROM content_logs
+	//         GROUP BY system_content_id, delta_node_uuid
+	//     ) subquery;
+	DB.Raw("SELECT SUM(cnt) as total_rows FROM (SELECT COUNT(*) as cnt FROM content_logs GROUP BY system_content_id, delta_node_uuid) subquery").Find(&totalContentConsumed)
+	//DB.Raw("select count(*) from content_logs").Count(&totalContentConsumed)
 
 	var totalTransferStarted int64
-	DB.Raw("select count(*) from content_logs where status = 'transfer-started'").Count(&totalTransferStarted)
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//         SELECT COUNT(*) as cnt
+	//         FROM content_logs
+	//         WHERE status = 'transfer-started'
+	//         GROUP BY system_content_id, delta_node_uuid
+	//     ) subquery;
+	err := DB.Model(model.ContentLogs{}).Where("status = ?", "transfer-started").Count(&totalTransferStarted).Error
+	if err != nil {
+		fmt.Println("Error in GetOpenTotalInfoStats", err)
+		return nil, err
+	}
 
 	var totalTransferFinished int64
-	DB.Raw("select count(*) from content_logs where status = 'transfer-finished'").Count(&totalTransferFinished)
-
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//         SELECT COUNT(*) as cnt
+	//         FROM content_logs
+	//         WHERE status = 'transfer-started'
+	//         GROUP BY system_content_id, delta_node_uuid
+	//     ) subquery;
+	err = DB.Model(model.ContentLogs{}).Where("status = ?", "transfer-finished").Count(&totalTransferFinished).Error
+	if err != nil {
+		fmt.Println("Error in GetOpenTotalInfoStats", err)
+		return nil, err
+	}
 	var totalProposalMade int64
-	DB.Raw("select count(*) from content_deal_proposal_logs").Count(&totalProposalMade)
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//	SELECT COUNT(*) as cnt
+	//FROM content_deal_proposal_logs
+	//GROUP BY system_content_deal_proposal_id, delta_node_uuid
+	//) subquery;
+	DB.Raw("select count(*) from content_deal_proposal_logs").Find(&totalProposalMade)
 
 	var totalCommitmentPiece int64
-	DB.Raw("select count(*) from piece_commitment_logs").Count(&totalCommitmentPiece)
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//	SELECT COUNT(*) as cnt
+	//FROM piece_commitment_logs
+	//GROUP BY system_content_piece_commitment_id, delta_node_uuid
+	//) subquery;
+	DB.Raw("select count(*) from piece_commitment_logs").Find(&totalCommitmentPiece)
 
 	var totalPieceCommitted int64
-	DB.Raw("select count(*) from piece_commitment_logs where status = 'committed'").Count(&totalPieceCommitted)
+	//SELECT SUM(cnt) as total_rows
+	//FROM (
+	//	SELECT COUNT(*) as cnt
+	//FROM piece_commitment_logs
+	//WHERE status = 'committed'
+	//GROUP BY system_content_piece_commitment_id, delta_node_uuid
+	//) subquery;
+	DB.Raw("select count(*) from piece_commitment_logs where status = 'committed'").Find(&totalPieceCommitted)
 
 	var totalMiners int64
+	//SELECT count(cnt) as total_rows
+	//FROM (
+	//	SELECT miner as cnt
+	//FROM content_miner_logs
+	//GROUP BY miner
+	//) subquery;
 	rows, err := DB.Raw("select distinct(miner) from content_miner_logs").Rows()
 	if err != nil {
 		return nil, err
@@ -37,7 +95,7 @@ func GetOpenTotalInfoStats() (interface{}, error) {
 	DB.Raw("select sum(size) from content_logs").Count(&totalStorageAllocated)
 
 	var totalProposalSent int64
-	DB.Raw("select count(*) from content_logs where status = 'deal-proposal-sent'").Count(&totalProposalSent)
+	DB.Raw("select count(*) from content_logs c where status = 'deal-proposal-sent' and c.system_content_id in (select c.system_content_id from content_logs where status = 'deal-proposal-sent')").Count(&totalProposalSent)
 
 	var totalSealedDealInBytes int64
 	DB.Raw("select sum(size) from content_logs where status in ('transfer-started','transfer-finished','deal-proposal-sent')").Scan(&totalSealedDealInBytes)

--- a/dao/statistics.go
+++ b/dao/statistics.go
@@ -5,95 +5,35 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-//-- deals attempted and size (with created_at filter)
-//select sum(cnt) as total_rows from (select count(dt_chan) as cnt from content_deal_logs group by dt_chan) subquery;
-//select sum(cnt) as total_rows from (select count(dt_chan) as cnt from content_deal_logs where (created_at between '2023-01-01' and '2023-12-30') group by dt_chan) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,cd.dt_chan from content_deal_logs cd, content_logs c where cd.content = c.system_content_id and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,cd.dt_chan) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,cd.dt_chan from content_deal_logs cd, content_logs c where cd.content = c.system_content_id and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,cd.dt_chan) subquery;
-//
-//-- e2e deals attempted and size (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and (created_at between '2023-01-01' and '2023-12-30') and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
-//
-//-- import deals attempted and size (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'import' and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
-//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'import' and (created_at between '2023-01-01' and '2023-12-30') and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
-//
-//-- e2e succeeded (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started','transfer-finished') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started','transfer-finished') and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
-//
-//-- import succeeded (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('deal-proposal-sent') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
-//
-//-- e2e failed (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status not in ('transfer-started','transfer-finished') group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status not in ('transfer-started','transfer-finished') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//
-//-- import failed (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status not in ('deal-proposal-sent') group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status not in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//
-//-- import failed (with created_at filter)
-//select sum(cnt) as total_rows from (select count(system_content_deal_id) as cnt from content_deal_logs cd, content_logs c where c.system_content_id = cd.content and c.connection_mode = 'import' and c.status not in ('deal-proposal-sent') group by system_content_deal_id) subquery;
-//select sum(cnt) as total_rows from (select count(system_content_deal_id) as cnt from content_deal_logs cd, content_logs c where c.system_content_id = cd.content and c.connection_mode = 'import' and c.status not in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_deal_id) subquery;
-//
-//-- total deals active (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//
-//-- total e2e deals active (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//
-//-- total import deals active (with created_at filter)
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('making-deal-proposal') group by system_content_id) subquery;
-//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('making-deal-proposal') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
-//
-//-- total number of SPs (with created_at filter)
-//select count(miners) as total_rows from (select distinct(miner) as miners from content_miner_logs group by miner) subquery;
-//
-//-- total number of unique delta nodes (with created_at filter)
-//select count(delta_node) as total_rows from (select distinct(delta_node_uuid) as delta_node from delta_startup_logs group by delta_node_uuid) subquery;
-//
-//select distinct(delta_node_uuid) as delta_node from delta_startup_logs group by delta_node_uuid;
-//
-//select * from content_deal_logs cd where (cd.delta_node_uuid is null or cd.delta_node_uuid = '') and requester_info = '139.178.81.109' order by created_at desc;
-//
-//select count(*) from content_deal_logs cd where (cd.delta_node_uuid is null or cd.delta_node_uuid = '') and node_info = 'shuttle-4';
-//select * from content_deal_logs cd where cd.delta_node_uuid is null or cd.delta_node_uuid = '' order by created_at desc;
-//select * from content_deal_logs cd where cd.delta_node_uuid is null order by created_at desc;
-
 // function to get all totals info
 func GetOpenTotalInfoStats() (interface{}, error) {
 
 	// total deals attempted
 	var statsTotal struct {
-		TotalDealsAttempted               int `json:"total_deals_attempted,omitempty"`
-		TotalE2EDealsAttempted            int `json:"total_e2e_deals_attempted,omitempty"`
-		TotalImportDealsAttempted         int `json:"total_import_deals_attempted,omitempty"`
-		TotalDealsAttemptedSize           int `json:"total_deals_attempted_size,omitempty"`
-		TotalE2EDealsAttemptedSize        int `json:"total_e2e_deals_attempted_size,omitempty"`
-		TotalImportDealsAttemptedSize     int `json:"total_import_deals_attempted_size,omitempty"`
-		TotalDealsSucceeded               int `json:"total_deals_succeeded,omitempty"`
-		TotalE2ESucceeded                 int `json:"total_e2e_succeeded,omitempty"`
-		TotalImportSucceeded              int `json:"total_import_succeeded,omitempty"`
-		TotalDealsSucceededSize           int `json:"total_deals_succeeded_size,omitempty"`
-		TotalE2ESucceededSize             int `json:"total_e2e_succeeded_size,omitempty"`
-		TotalImportSucceededSize          int `json:"total_import_succeeded_size,omitempty"`
-		TotalInProgressDeals24h           int `json:"total_in_progress_deals_24h,omitempty"`
-		TotalInProgressE2EDeals24h        int `json:"total_in_progress_e2e_deals_24h,omitempty"`
-		TotalInProgressImportDeals24h     int `json:"total_in_progress_import_deals_24h,omitempty"`
-		TotalInProgressDealsSize24h       int `json:"total_in_progress_deals_size_24h,omitempty"`
-		TotalInProgressE2EDealsSize24h    int `json:"total_in_progress_e2e_deals_size_24h,omitempty"`
-		TotalInProgressImportDealsSize24h int `json:"total_in_progress_import_deals_size_24h,omitempty"`
-		TotalNumberOfSpsWorkWith          int `json:"total_number_of_sps_worked_with,omitempty"`
-		TotalNumberOfUniqueDeltaNodes     int `json:"total_number_of_unique_delta_nodes,omitempty"`
+		TotalDealsAttempted                       int `json:"total_deals_attempted,omitempty"`
+		TotalE2EDealsAttempted                    int `json:"total_e2e_deals_attempted,omitempty"`
+		TotalImportDealsAttempted                 int `json:"total_import_deals_attempted,omitempty"`
+		TotalPieceCommitmentsComputeAttempted     int `json:"total_piece_commitments_compute_attempted,omitempty"`
+		TotalDealsAttemptedSize                   int `json:"total_deals_attempted_size,omitempty"`
+		TotalE2EDealsAttemptedSize                int `json:"total_e2e_deals_attempted_size,omitempty"`
+		TotalImportDealsAttemptedSize             int `json:"total_import_deals_attempted_size,omitempty"`
+		TotalPieceCommitmentsComputeAttemptedSize int `json:"total_piece_commitments_compute_attempted_size,omitempty"`
+		TotalDealsSucceeded                       int `json:"total_deals_succeeded,omitempty"`
+		TotalE2ESucceeded                         int `json:"total_e2e_succeeded,omitempty"`
+		TotalImportSucceeded                      int `json:"total_import_succeeded,omitempty"`
+		TotalPieceCommitmentsComputeSucceeded     int `json:"total_piece_commitments_compute_succeeded,omitempty"`
+		TotalDealsSucceededSize                   int `json:"total_deals_succeeded_size,omitempty"`
+		TotalE2ESucceededSize                     int `json:"total_e2e_succeeded_size,omitempty"`
+		TotalImportSucceededSize                  int `json:"total_import_succeeded_size,omitempty"`
+		TotalPieceCommitmentsComputeSucceededSize int `json:"total_piece_commitments_compute_succeeded_size,omitempty"`
+		TotalInProgressDeals24h                   int `json:"total_in_progress_deals_24h,omitempty"`
+		TotalInProgressE2EDeals24h                int `json:"total_in_progress_e2e_deals_24h,omitempty"`
+		TotalInProgressImportDeals24h             int `json:"total_in_progress_import_deals_24h,omitempty"`
+		TotalInProgressDealsSize24h               int `json:"total_in_progress_deals_size_24h,omitempty"`
+		TotalInProgressE2EDealsSize24h            int `json:"total_in_progress_e2e_deals_size_24h,omitempty"`
+		TotalInProgressImportDealsSize24h         int `json:"total_in_progress_import_deals_size_24h,omitempty"`
+		TotalNumberOfSpsWorkWith                  int `json:"total_number_of_sps_worked_with,omitempty"`
+		TotalNumberOfUniqueDeltaNodes             int `json:"total_number_of_unique_delta_nodes,omitempty"`
 	}
 
 	val, ok := Cacher.Get("statsTotal")
@@ -128,6 +68,24 @@ func GetOpenTotalInfoStats() (interface{}, error) {
 				return err
 			}
 			statsTotal.TotalE2EDealsAttempted = totalE2EDealsAttempted
+
+			var totalPieceCommitmentsComputeAttempted int
+			row = tx.Raw("select sum(cnt) as total_rows from (select count(p.piece) as cnt from piece_commitment_logs p group by p.piece) subquery").Row()
+			err = row.Scan(&totalPieceCommitmentsComputeAttempted)
+			if err != nil {
+				fmt.Println("Error in getting total piece commitments compute attempted", err)
+				return err
+			}
+			statsTotal.TotalPieceCommitmentsComputeAttempted = totalPieceCommitmentsComputeAttempted
+
+			var totalPieceCommitmentsComputeAttemptedSize int
+			row = tx.Raw("select sum(cnt) as total_rows from (select count(p.piece) as cnt from piece_commitment_logs p where p.status = 'committed' group by p.piece) subquery").Row()
+			err = row.Scan(&totalPieceCommitmentsComputeAttemptedSize)
+			if err != nil {
+				fmt.Println("Error in getting total piece commitments compute attempted size", err)
+				return err
+			}
+			statsTotal.TotalPieceCommitmentsComputeAttemptedSize = totalPieceCommitmentsComputeAttemptedSize
 
 			var totalE2EDealsAttemptedSize int
 			row = tx.Raw("select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and (system_content_id is null or system_content_id is not null) group by c.size,system_content_id) subquery").Row()
@@ -182,6 +140,24 @@ func GetOpenTotalInfoStats() (interface{}, error) {
 				return err
 			}
 			statsTotal.TotalE2ESucceeded = totalE2EDealsSucceeded
+
+			var totalPieceCommitmentsComputeSucceeded int
+			row = tx.Raw("select sum(cnt) as total_rows from (select count(p.piece) as cnt from piece_commitment_logs p where p.status = 'committed' group by p.piece) subquery").Row()
+			err = row.Scan(&totalPieceCommitmentsComputeSucceeded)
+			if err != nil {
+				fmt.Println("Error in getting total piece commitments compute succeeded", err)
+				return err
+			}
+			statsTotal.TotalPieceCommitmentsComputeSucceeded = totalPieceCommitmentsComputeSucceeded
+
+			var totalPieceCommitmentsComputeSucceededSize int
+			row = tx.Raw("select sum(size) as total_size_sum from (select p.size as size from piece_commitment_logs p where p.status = 'committed' group by p.size,p.piece) subquery").Row()
+			err = row.Scan(&totalPieceCommitmentsComputeSucceededSize)
+			if err != nil {
+				fmt.Println("Error in getting total piece commitments compute succeeded size", err)
+				return err
+			}
+			statsTotal.TotalPieceCommitmentsComputeSucceededSize = totalPieceCommitmentsComputeSucceededSize
 
 			var totalE2EDealsSucceededSize int
 			row = tx.Raw("select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started','transfer-finished') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by c.size,system_content_id) subquery").Row()

--- a/dao/statistics.go
+++ b/dao/statistics.go
@@ -1,131 +1,72 @@
 package dao
 
-import (
-	"fmt"
-	"github.com/application-research/delta-metrics-rest/model"
-)
+//-- deals attempted and size (with created_at filter)
+//select sum(cnt) as total_rows from (select count(dt_chan) as cnt from content_deal_logs group by dt_chan) subquery;
+//select sum(cnt) as total_rows from (select count(dt_chan) as cnt from content_deal_logs where (created_at between '2023-01-01' and '2023-12-30') group by dt_chan) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,cd.dt_chan from content_deal_logs cd, content_logs c where cd.content = c.system_content_id and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,cd.dt_chan) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,cd.dt_chan from content_deal_logs cd, content_logs c where cd.content = c.system_content_id and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,cd.dt_chan) subquery;
+//
+//-- e2e deals attempted and size (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'e2e' and (created_at between '2023-01-01' and '2023-12-30') and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
+//
+//-- import deals attempted and size (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'import' and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
+//select sum(size) as total_size_sum from (select c.size as size,system_content_id from content_logs c where c.connection_mode = 'import' and (created_at between '2023-01-01' and '2023-12-30') and (system_content_id is null or system_content_id is not null) and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '') group by c.size,system_content_id) subquery;
+//
+//-- e2e succeeded (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started','transfer-finished') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started','transfer-finished') and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
+//
+//-- import succeeded (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('deal-proposal-sent') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') and (c.delta_node_uuid is not null or c.delta_node_uuid is null or c.delta_node_uuid = '')  group by system_content_id) subquery;
+//
+//-- e2e failed (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status not in ('transfer-started','transfer-finished') group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status not in ('transfer-started','transfer-finished') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//
+//-- import failed (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status not in ('deal-proposal-sent') group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status not in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//
+//-- import failed (with created_at filter)
+//select sum(cnt) as total_rows from (select count(system_content_deal_id) as cnt from content_deal_logs cd, content_logs c where c.system_content_id = cd.content and c.connection_mode = 'import' and c.status not in ('deal-proposal-sent') group by system_content_deal_id) subquery;
+//select sum(cnt) as total_rows from (select count(system_content_deal_id) as cnt from content_deal_logs cd, content_logs c where c.system_content_id = cd.content and c.connection_mode = 'import' and c.status not in ('deal-proposal-sent') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_deal_id) subquery;
+//
+//-- total deals active (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//
+//-- total e2e deals active (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'e2e' and status in ('transfer-started') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//
+//-- total import deals active (with created_at filter)
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('making-deal-proposal') group by system_content_id) subquery;
+//select sum(cnt) as total_rows from (select count(*) as cnt from content_logs c where c.connection_mode = 'import' and status in ('making-deal-proposal') and (created_at between '2023-01-01' and '2023-12-30') group by system_content_id) subquery;
+//
+//-- total number of SPs (with created_at filter)
+//select count(miners) as total_rows from (select distinct(miner) as miners from content_miner_logs group by miner) subquery;
+//
+//-- total number of unique delta nodes (with created_at filter)
+//select count(delta_node) as total_rows from (select distinct(delta_node_uuid) as delta_node from delta_startup_logs group by delta_node_uuid) subquery;
+//
+//select distinct(delta_node_uuid) as delta_node from delta_startup_logs group by delta_node_uuid;
+//
+//select * from content_deal_logs cd where (cd.delta_node_uuid is null or cd.delta_node_uuid = '') and requester_info = '139.178.81.109' order by created_at desc;
+//
+//select count(*) from content_deal_logs cd where (cd.delta_node_uuid is null or cd.delta_node_uuid = '') and node_info = 'shuttle-4';
+//select * from content_deal_logs cd where cd.delta_node_uuid is null or cd.delta_node_uuid = '' order by created_at desc;
+//select * from content_deal_logs cd where cd.delta_node_uuid is null order by created_at desc;
 
 // function to get all totals info
 func GetOpenTotalInfoStats() (interface{}, error) {
 
-	var totalContentConsumed int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//         SELECT COUNT(*) as cnt
-	//         FROM content_logs
-	//         GROUP BY system_content_id, delta_node_uuid
-	//     ) subquery;
-	DB.Raw("SELECT SUM(cnt) as total_rows FROM (SELECT COUNT(*) as cnt FROM content_logs GROUP BY system_content_id, delta_node_uuid) subquery").Find(&totalContentConsumed)
-	//DB.Raw("select count(*) from content_logs").Count(&totalContentConsumed)
+	return nil, nil
 
-	var totalTransferStarted int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//         SELECT COUNT(*) as cnt
-	//         FROM content_logs
-	//         WHERE status = 'transfer-started'
-	//         GROUP BY system_content_id, delta_node_uuid
-	//     ) subquery;
-	err := DB.Model(model.ContentLogs{}).Where("status = ?", "transfer-started").Count(&totalTransferStarted).Error
-	if err != nil {
-		fmt.Println("Error in GetOpenTotalInfoStats", err)
-		return nil, err
-	}
-
-	var totalTransferFinished int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//         SELECT COUNT(*) as cnt
-	//         FROM content_logs
-	//         WHERE status = 'transfer-started'
-	//         GROUP BY system_content_id, delta_node_uuid
-	//     ) subquery;
-	err = DB.Model(model.ContentLogs{}).Where("status = ?", "transfer-finished").Count(&totalTransferFinished).Error
-	if err != nil {
-		fmt.Println("Error in GetOpenTotalInfoStats", err)
-		return nil, err
-	}
-	var totalProposalMade int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//	SELECT COUNT(*) as cnt
-	//FROM content_deal_proposal_logs
-	//GROUP BY system_content_deal_proposal_id, delta_node_uuid
-	//) subquery;
-	DB.Raw("select count(*) from content_deal_proposal_logs").Find(&totalProposalMade)
-
-	var totalCommitmentPiece int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//	SELECT COUNT(*) as cnt
-	//FROM piece_commitment_logs
-	//GROUP BY system_content_piece_commitment_id, delta_node_uuid
-	//) subquery;
-	DB.Raw("select count(*) from piece_commitment_logs").Find(&totalCommitmentPiece)
-
-	var totalPieceCommitted int64
-	//SELECT SUM(cnt) as total_rows
-	//FROM (
-	//	SELECT COUNT(*) as cnt
-	//FROM piece_commitment_logs
-	//WHERE status = 'committed'
-	//GROUP BY system_content_piece_commitment_id, delta_node_uuid
-	//) subquery;
-	DB.Raw("select count(*) from piece_commitment_logs where status = 'committed'").Find(&totalPieceCommitted)
-
-	var totalMiners int64
-	//SELECT count(cnt) as total_rows
-	//FROM (
-	//	SELECT miner as cnt
-	//FROM content_miner_logs
-	//GROUP BY miner
-	//) subquery;
-	rows, err := DB.Raw("select distinct(miner) from content_miner_logs").Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var miner string
-		rows.Scan(&miner)
-		totalMiners++
-	}
-
-	var totalStorageAllocated int64
-	DB.Raw("select sum(size) from content_logs").Count(&totalStorageAllocated)
-
-	var totalProposalSent int64
-	DB.Raw("select count(*) from content_logs c where status = 'deal-proposal-sent' and c.system_content_id in (select c.system_content_id from content_logs where status = 'deal-proposal-sent')").Count(&totalProposalSent)
-
-	var totalSealedDealInBytes int64
-	DB.Raw("select sum(size) from content_logs where status in ('transfer-started','transfer-finished','deal-proposal-sent')").Scan(&totalSealedDealInBytes)
-
-	var totalImportDeals int64
-	DB.Raw("select count(*) from content_logs where connection_mode = 'import'").Count(&totalImportDeals)
-
-	var totalE2EDeals int64
-	DB.Raw("select count(*) from content_logs where connection_mode = 'e2e'").Count(&totalE2EDeals)
-
-	var totalE2EDealsInBytes int64
-	DB.Raw("select sum(size) from content_logs where connection_mode = 'e2e'").Count(&totalE2EDealsInBytes)
-
-	var totalImportDealsInBytes int64
-	DB.Raw("select sum(size) from content_logs where connection_mode = 'import'").Count(&totalImportDealsInBytes)
-
-	return map[string]interface{}{
-		"total_content_consumed":      totalContentConsumed,
-		"total_transfer_started":      totalTransferStarted,
-		"total_transfer_finished":     totalTransferFinished,
-		"total_piece_commitment_made": totalCommitmentPiece,
-		"total_piece_committed":       totalPieceCommitted,
-		"total_miners":                totalMiners,
-		"total_storage_allocated":     totalStorageAllocated,
-		"total_proposal_made":         totalProposalMade,
-		"total_proposal_sent":         totalProposalSent,
-		"total_sealed_deal_in_bytes":  totalSealedDealInBytes,
-		"total_import_deals":          totalImportDeals,
-		"total_e2e_deals":             totalE2EDeals,
-		"total_e2e_deals_in_bytes":    totalE2EDealsInBytes,
-		"total_import_deals_in_bytes": totalImportDealsInBytes,
-	}, nil
 }

--- a/dao/statistics.go
+++ b/dao/statistics.go
@@ -79,7 +79,7 @@ func GetOpenTotalInfoStats() (interface{}, error) {
 			statsTotal.TotalPieceCommitmentsComputeAttempted = totalPieceCommitmentsComputeAttempted
 
 			var totalPieceCommitmentsComputeAttemptedSize int
-			row = tx.Raw("select sum(cnt) as total_rows from (select count(p.piece) as cnt from piece_commitment_logs p where p.status = 'committed' group by p.piece) subquery").Row()
+			row = tx.Raw("select sum(size) as total_size_sum from (select p.size as size from piece_commitment_logs p group by p.size,p.piece) subquery").Row()
 			err = row.Scan(&totalPieceCommitmentsComputeAttemptedSize)
 			if err != nil {
 				fmt.Println("Error in getting total piece commitments compute attempted size", err)

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/paskal/golang-lru v0.6.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/droundy/goopt v0.0.0-20220217183150-48d6390ad4d1
+	github.com/eko/gocache/lib/v4 v4.1.3
+	github.com/eko/gocache/store/bigcache/v4 v4.1.2
 	github.com/gin-gonic/gin v1.9.0
 	github.com/guregu/null v4.0.0+incompatible
 	github.com/jinzhu/gorm v1.9.16
@@ -19,7 +21,9 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -35,6 +39,8 @@ require (
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -47,10 +53,15 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/prometheus/client_golang v1.14.0 // indirect
+	github.com/prometheus/client_model v0.3.0 // indirect
+	github.com/prometheus/common v0.37.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -60,6 +71,7 @@ require (
 	github.com/ugorji/go/codec v1.2.9 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/main.go
+++ b/main.go
@@ -150,8 +150,21 @@ func main() {
 
 	// cache
 	dao.Cacher = explru.NewExpirableLRU(CacheSize, nil, CacheDuration, CachePurgeEveryDuration)
+
+	// Recache
+	go Recache()
 	go GinServer()
 	LoopForever()
+}
+
+func Recache() {
+	for {
+		_, err := dao.GetOpenTotalInfoStats()
+		if err != nil {
+			fmt.Printf("Error while recaching %s\n", err)
+		}
+		time.Sleep(30 * time.Minute)
+	}
 }
 
 // LoopForever on signal processing

--- a/main.go
+++ b/main.go
@@ -3,22 +3,20 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/viper"
-	"log"
-	"os"
-	"os/signal"
-	"syscall"
-
+	"github.com/droundy/goopt"
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mssql"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-
-	"github.com/droundy/goopt"
-	"github.com/gin-gonic/gin"
-	"github.com/jinzhu/gorm"
+	"github.com/spf13/viper"
 	"github.com/swaggo/files"       // swagger embed files
 	"github.com/swaggo/gin-swagger" // gin-swagger middleware
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/application-research/delta-metrics-rest/api"
 	"github.com/application-research/delta-metrics-rest/dao"
@@ -144,6 +142,8 @@ func main() {
 	dao.Logger = func(ctx context.Context, sql string) {
 		fmt.Printf("SQL: %s\n", sql)
 	}
+
+	// cache
 
 	go GinServer()
 	LoopForever()


### PR DESCRIPTION
Added a stats endpoint that will show the following
```
{
   "total_deals_attempted":267697,
   "total_e2e_deals_attempted":491507,
   "total_import_deals_attempted":10180,
   "total_piece_commitments_compute_attempted":51177,
   "total_deals_attempted_size":128385902800247,
   "total_e2e_deals_attempted_size":20730131823444,
   "total_import_deals_attempted_size":96602448409205,
   "total_piece_commitments_compute_attempted_size":21718,
   "total_deals_succeeded":15365,
   "total_e2e_succeeded":13782,
   "total_import_succeeded":932,
   "total_piece_commitments_compute_succeeded":21718,
   "total_deals_succeeded_size":31494583601709,
   "total_e2e_succeeded_size":15515646097948,
   "total_import_succeeded_size":15978257159302,
   "total_piece_commitments_compute_succeeded_size":52121893212661,
   "total_in_progress_deals_24h":1624,
   "total_in_progress_e2e_deals_24h":660,
   "total_in_progress_import_deals_24h":953,
   "total_number_of_sps_worked_with":112,
   "total_number_of_unique_delta_nodes":86
}
```